### PR TITLE
middleware.py: Add FAKEUSERAGENT_FALLBACK configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,3 +65,11 @@ To use with middlewares of random proxy such as `scrapy-proxies <https://github.
    :target: http://badge.fury.io/gh/alecxe%2Fscrapy-fake-useragent
 .. |Requirements Status| image:: https://requires.io/github/alecxe/scrapy-fake-useragent/requirements.svg?branch=master
    :target: https://requires.io/github/alecxe/scrapy-fake-useragent/requirements/?branch=master
+
+Configuring Fake-UserAgent fallback
+----------------------------------
+
+There's a configuration parameter ``FAKEUSERAGENT_FALLBACK`` defaulting to
+``None``. You can set it to a string value, for example ``Mozilla`` or
+``Your favorite browser``, this configuration can completely disable any
+annoying exception.

--- a/scrapy_fake_useragent/middleware.py
+++ b/scrapy_fake_useragent/middleware.py
@@ -7,7 +7,8 @@ class RandomUserAgentMiddleware(object):
     def __init__(self, crawler):
         super(RandomUserAgentMiddleware, self).__init__()
 
-        self.ua = UserAgent()
+        fallback = crawler.settings.get('FAKEUSERAGENT_FALLBACK', None)
+        self.ua = UserAgent(fallback=fallback)
         self.per_proxy = crawler.settings.get('RANDOM_UA_PER_PROXY', False)
         self.ua_type = crawler.settings.get('RANDOM_UA_TYPE', 'random')
         self.proxy2ua = {}


### PR DESCRIPTION
Add `FAKEUSERAGENT_FALLBACK` configuration which can be used to
compeletely disable any annoying exception.

Closes https://github.com/alecxe/scrapy-fake-useragent/issues/14