### PR TITLE
Update providers.py

### DIFF
--- a/scrapy_fake_useragent/providers.py
+++ b/scrapy_fake_useragent/providers.py
@@ -56,7 +56,7 @@ class FakeUserAgentProvider(BaseProvider):
         self._ua_type = settings.get('FAKE_USERAGENT_RANDOM_UA_TYPE',
                                      self.DEFAULT_UA_TYPE)
 
-        fallback = settings.get('FAKEUSERAGENT_FALLBACK', None)
+        fallback = settings.get('FAKEUSERAGENT_FALLBACK', '')
         self._ua = fake_useragent.UserAgent(fallback=fallback)
 
     def get_random_ua(self):


### PR DESCRIPTION
Set the `fallback` to empty string when `FAKEUSERAGENT_FALLBACK` is not provided in the `settings.py`, because it returns `AssertionError: fallback must be a string` when set to `None`.