### PR TITLE
Add support for `RETRY_EXCEPTIONS` setting

### DIFF
--- a/scrapy_fake_useragent/middleware.py
+++ b/scrapy_fake_useragent/middleware.py
@@ -76,6 +76,10 @@ class RetryUserAgentMiddleware(RetryMiddleware, RandomUserAgentBase):
         RetryMiddleware.__init__(self, crawler.settings)
         RandomUserAgentBase.__init__(self, crawler)
 
+        # Support for Scrapy 2.10 and RETRY_EXCEPTIONS setting
+        if hasattr(self, 'exceptions_to_retry'):
+            self.EXCEPTIONS_TO_RETRY = self.exceptions_to_retry
+
     @classmethod
     def from_crawler(cls, crawler):
         return cls(crawler)


### PR DESCRIPTION
Resolves #41.

I tested locally with Scrapy 2.9.0, 2.10.0 and 2.11.0.
2.10 is the version with exception upon accessing `EXCEPTIONS_TO_RETRY`. In 2.11 this error was fixed.

On all versions middleware does not fail when `process_exception` is called. On 2.10+ the middleware also respects setting `RETRY_EXCEPTIONS`.

I am not sure how to add tests with specific scrapy version.